### PR TITLE
‘swSocket’ was not declared

### DIFF
--- a/swoole_postgresql_coro.cc
+++ b/swoole_postgresql_coro.cc
@@ -1288,7 +1288,7 @@ static int swoole_postgresql_coro_close(zval *zobject)
     }
     SwooleG.main_reactor->del(SwooleG.main_reactor, object->fd);
     
-    swSocket *_socket = swReactor_get(SwooleG.main_reactor, object->fd);
+    swConnection *_socket = swReactor_get(SwooleG.main_reactor, object->fd);
     if (_socket->object)
     {
         PGresult *res;


### PR DESCRIPTION
swoole_postgresql_coro.cc:1291:5: 错误：‘swSocket’ was not declared in this scope;