### PR TITLE
New features and fixes

### DIFF
--- a/swoole_postgresql_coro.cc
+++ b/swoole_postgresql_coro.cc
@@ -122,6 +122,7 @@ static PHP_METHOD(swoole_postgresql_coro, execute);
 static PHP_METHOD(swoole_postgresql_coro, fetchAll);
 static PHP_METHOD(swoole_postgresql_coro, affectedRows);
 static PHP_METHOD(swoole_postgresql_coro, numRows);
+static PHP_METHOD(swoole_postgresql_coro, fieldCount);
 static PHP_METHOD(swoole_postgresql_coro, metaData);
 static PHP_METHOD(swoole_postgresql_coro, fetchObject);
 static PHP_METHOD(swoole_postgresql_coro, fetchAssoc);
@@ -176,6 +177,10 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_pg_num_rows, 0, 0, 0)
     ZEND_ARG_INFO(0, result)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_pg_field_count, 0, 0, 0)
+    ZEND_ARG_INFO(0, result)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_pg_meta_data, 0, 0, 1)
     ZEND_ARG_INFO(0, table_name)
 ZEND_END_ARG_INFO()
@@ -219,6 +224,7 @@ static const zend_function_entry swoole_postgresql_coro_methods[] =
     PHP_ME(swoole_postgresql_coro, fetchAll, arginfo_pg_fetch_all, ZEND_ACC_PUBLIC)
     PHP_ME(swoole_postgresql_coro, affectedRows, arginfo_pg_affected_rows, ZEND_ACC_PUBLIC)
     PHP_ME(swoole_postgresql_coro, numRows, arginfo_pg_num_rows, ZEND_ACC_PUBLIC)
+    PHP_ME(swoole_postgresql_coro, fieldCount, arginfo_pg_field_count, ZEND_ACC_PUBLIC)
     PHP_ME(swoole_postgresql_coro, metaData, arginfo_pg_meta_data, ZEND_ACC_PUBLIC)
     PHP_ME(swoole_postgresql_coro, escape, arginfo_pg_escape, ZEND_ACC_PUBLIC)
     PHP_ME(swoole_postgresql_coro, fetchObject, arginfo_pg_fetch_object, ZEND_ACC_PUBLIC)
@@ -1051,6 +1057,22 @@ static PHP_METHOD(swoole_postgresql_coro, numRows) {
     }
 
     RETVAL_LONG(PQntuples(pgsql_result));
+}
+
+//query's field count
+static PHP_METHOD(swoole_postgresql_coro, fieldCount) {
+    zval *result;
+    PGresult *pgsql_result;
+
+    ZEND_PARSE_PARAMETERS_START(1,1)
+    Z_PARAM_RESOURCE(result)
+    ZEND_PARSE_PARAMETERS_END_EX(RETURN_FALSE);
+
+    if ((pgsql_result = (PGresult *)zend_fetch_resource(Z_RES_P(result), "PostgreSQL result", le_result)) == NULL) {
+        RETURN_FALSE;
+    }
+
+    RETVAL_LONG(PQnfields(pgsql_result));
 }
 
 static PHP_METHOD(swoole_postgresql_coro, metaData) {

--- a/swoole_postgresql_coro.cc
+++ b/swoole_postgresql_coro.cc
@@ -595,8 +595,7 @@ static void set_error_diag(const pg_object *object, const PGresult *pgsql_result
     zend_update_property(swoole_postgresql_coro_ce, object->object, ZEND_STRL("resultDiag"), &result_diag);
 }
 
-static int query_result_parse(pg_object *object)
-{
+static int query_result_parse(pg_object *object) {
     PGresult *pgsql_result;
     ExecStatusType status;
 

--- a/swoole_postgresql_coro.cc
+++ b/swoole_postgresql_coro.cc
@@ -674,7 +674,7 @@ static int prepare_result_parse(pg_object *object) {
             PQclear(pgsql_result);
             ZVAL_FALSE(&return_value);
             swoole_event_del(object->socket);
-            zend_update_property_string(swoole_postgresql_coro_ce, object->object, ZEND_STRL("error"));
+            zend_update_property_string(swoole_postgresql_coro_ce, object->object, ZEND_STRL("error"), err_msg);
             ret = PHPCoroutine::resume_m(context, &return_value, retval);
             if (ret == Coroutine::ERR_END && retval) {
                 zval_ptr_dtor(retval);

--- a/swoole_postgresql_coro.cc
+++ b/swoole_postgresql_coro.cc
@@ -679,10 +679,14 @@ static int prepare_result_parse(pg_object *object) {
             if (ret == Coroutine::ERR_END && retval) {
                 zval_ptr_dtor(retval);
             }
+            if (error != 0) {
+                php_swoole_fatal_error(E_WARNING, "socket error. Error: %s [%d]", strerror(error), error);
+            }
             break;
         case PGRES_COMMAND_OK: /* successful command that did not return rows */
             /* Wait to finish sending buffer */
             //res = PQflush(object->conn);
+            PQclear(pgsql_result);
             swoole_event_del(object->socket);
             ZVAL_TRUE(&return_value);
             zend_update_property_null(swoole_postgresql_coro_ce, object->object, ZEND_STRL("error"));
@@ -696,16 +700,15 @@ static int prepare_result_parse(pg_object *object) {
             }
             break;
         default:
+            PQclear(pgsql_result);
             swoole_event_del(object->socket);
             ZVAL_FALSE(&return_value);
             zend_update_property_string(swoole_postgresql_coro_ce, object->object, "error", 5, "Bad result returned to prepare");
             ret = PHPCoroutine::resume_m(context, &return_value, retval);
-            if (ret == SW_CORO_ERR_END && retval)
-            {
+            if (ret == Coroutine::ERR_END && retval) {
                 zval_ptr_dtor(retval);
             }
-            if (error != 0)
-            {
+            if (error != 0) {
                 php_swoole_fatal_error(E_WARNING, "socket error. Error: %s [%d]", strerror(error), error);
             }
             break;

--- a/swoole_postgresql_coro.cc
+++ b/swoole_postgresql_coro.cc
@@ -703,7 +703,7 @@ static int prepare_result_parse(pg_object *object) {
             PQclear(pgsql_result);
             swoole_event_del(object->socket);
             ZVAL_FALSE(&return_value);
-            zend_update_property_string(swoole_postgresql_coro_ce, object->object, "error", 5, "Bad result returned to prepare");
+            zend_update_property_string(swoole_postgresql_coro_ce, object->object, ZEND_STRL("error"), "Bad result returned to prepare");
             ret = PHPCoroutine::resume_m(context, &return_value, retval);
             if (ret == Coroutine::ERR_END && retval) {
                 zval_ptr_dtor(retval);


### PR DESCRIPTION
Changes:
* Fixed "prepare" method that always returns true (even when an error has occurred)
* Added "resultStatus" property so you can figure out how to interpret the result
* Added "resultDiag" property that can be very useful for error message building and for errors troubleshooting.
* Added "fieldCount" method that returns number of columns in the result set

### Testing error in prepare query
```php
$connection = new \Swoole\Coroutine\PostgreSQL();
$connection->connect("host=127.0.0.1 port=5432 user=postgres dbname=test");

$result = $connection->prepare('123', 'SELECT FROM rere');
var_dump($result, $connection);

$result = $connection->prepare('123', 'SELECT 1');
var_dump($result, $connection);
```

<details>
<summary>Output is (click me):</summary>

```
bool(false)
object(Swoole\Coroutine\PostgreSQL)#5 (4) {
  ["error"]=>
  string(86) "ERROR:  relation "rere" does not exist
LINE 1: SELECT FROM rere
                    ^
"
  ["errCode"]=>
  int(0)
  ["resultStatus"]=>
  int(7)
  ["resultDiag"]=>
  array(17) {
    ["severity"]=>
    string(5) "ERROR"
    ["sqlstate"]=>
    string(5) "42P01"
    ["message_primary"]=>
    string(30) "relation "rere" does not exist"
    ["message_detail"]=>
    NULL
    ["message_hint"]=>
    NULL
    ["statement_position"]=>
    string(2) "13"
    ["internal_position"]=>
    NULL
    ["internal_query"]=>
    NULL
    ["content"]=>
    NULL
    ["schema_name"]=>
    NULL
    ["table_name"]=>
    NULL
    ["column_name"]=>
    NULL
    ["datatype_name"]=>
    NULL
    ["constraint_name"]=>
    NULL
    ["source_file"]=>
    string(16) "parse_relation.c"
    ["source_line"]=>
    string(4) "1191"
    ["source_function"]=>
    string(15) "parserOpenTable"
  }
}
bool(true)
object(Swoole\Coroutine\PostgreSQL)#5 (4) {
  ["error"]=>
  NULL
  ["errCode"]=>
  int(0)
  ["resultStatus"]=>
  int(1)
  ["resultDiag"]=>
  NULL
}
```
</details>


### Testing error in query
```php
$result = $connection->query('SELECT * FROM test WHERE undefined_colmun = 1');
var_dump($result, $connection);
$result = $connection->query('SELECT * FROM test LIMIT 1');
var_dump($result, $connection);
```

<details>
<summary>Output is (click me):</summary>

```
bool(false)
object(Swoole\Coroutine\PostgreSQL)#5 (4) {
  ["error"]=>
  string(138) "ERROR:  column "undefined_colmun" does not exist
LINE 1: SELECT * FROM test WHERE undefined_colmun = 1
                                 ^
"
  ["errCode"]=>
  int(0)
  ["resultStatus"]=>
  int(7)
  ["resultDiag"]=>
  array(17) {
    ["severity"]=>
    string(5) "ERROR"
    ["sqlstate"]=>
    string(5) "42703"
    ["message_primary"]=>
    string(40) "column "undefined_colmun" does not exist"
    ["message_detail"]=>
    NULL
    ["message_hint"]=>
    NULL
    ["statement_position"]=>
    string(2) "26"
    ["internal_position"]=>
    NULL
    ["internal_query"]=>
    NULL
    ["content"]=>
    NULL
    ["schema_name"]=>
    NULL
    ["table_name"]=>
    NULL
    ["column_name"]=>
    NULL
    ["datatype_name"]=>
    NULL
    ["constraint_name"]=>
    NULL
    ["source_file"]=>
    string(16) "parse_relation.c"
    ["source_line"]=>
    string(4) "3349"
    ["source_function"]=>
    string(18) "errorMissingColumn"
  }
}
resource(17) of type (pgsql result)
object(Swoole\Coroutine\PostgreSQL)#5 (4) {
  ["error"]=>
  NULL
  ["errCode"]=>
  int(0)
  ["resultStatus"]=>
  int(2)
  ["resultDiag"]=>
  NULL
}
```
</details>


### Testing constraint violation
```php
$connection->query("CREATE TABLE test (domain VARCHAR(63), tld VARCHAR(63), PRIMARY KEY (domain, tld))");

$result = $connection->query("INSERT INTO test (domain, tld)VALUES('google', 'com')");
var_dump($result, $connection);
$result = $connection->query("INSERT INTO test (domain, tld)VALUES('google', 'com')");
var_dump($result, $connection);
```

<details>
<summary>Output is (click me):</summary>

```
resource(17) of type (pgsql result)
object(Swoole\Coroutine\PostgreSQL)#5 (4) {
  ["error"]=>
  NULL
  ["errCode"]=>
  int(0)
  ["resultStatus"]=>
  int(1)
  ["resultDiag"]=>
  NULL
}
bool(false)
object(Swoole\Coroutine\PostgreSQL)#5 (4) {
  ["error"]=>
  string(124) "ERROR:  duplicate key value violates unique constraint "test_pkey"
DETAIL:  Key (domain, tld)=(google, com) already exists.
"
  ["errCode"]=>
  int(0)
  ["resultStatus"]=>
  int(7)
  ["resultDiag"]=>
  array(17) {
    ["severity"]=>
    string(5) "ERROR"
    ["sqlstate"]=>
    string(5) "23505"
    ["message_primary"]=>
    string(58) "duplicate key value violates unique constraint "test_pkey""
    ["message_detail"]=>
    string(47) "Key (domain, tld)=(google, com) already exists."
    ["message_hint"]=>
    NULL
    ["statement_position"]=>
    NULL
    ["internal_position"]=>
    NULL
    ["internal_query"]=>
    NULL
    ["content"]=>
    NULL
    ["schema_name"]=>
    string(6) "public"
    ["table_name"]=>
    string(4) "test"
    ["column_name"]=>
    NULL
    ["datatype_name"]=>
    NULL
    ["constraint_name"]=>
    string(9) "test_pkey"
    ["source_file"]=>
    string(11) "nbtinsert.c"
    ["source_line"]=>
    string(3) "563"
    ["source_function"]=>
    string(16) "_bt_check_unique"
  }
}
```
</details>