### PR TITLE
Fix query results without field names

### DIFF
--- a/swoole_postgresql_coro.cc
+++ b/swoole_postgresql_coro.cc
@@ -998,8 +998,8 @@ static inline void php_pgsql_get_field_value(
  */
 int swoole_pgsql_result2array(PGresult *pg_result, zval *ret_array, long result_type) {
     zval row;
-    char *field_name;
-    size_t num_fields;
+    const char *field_name;
+    size_t num_fields, unknown_columns;
     int pg_numrows, pg_row;
     uint32_t i;
     assert(Z_TYPE_P(ret_array) == IS_ARRAY);
@@ -1009,11 +1009,18 @@ int swoole_pgsql_result2array(PGresult *pg_result, zval *ret_array, long result_
     }
     for (pg_row = 0; pg_row < pg_numrows; pg_row++) {
         array_init(&row);
+        unknown_columns = 0;
         for (i = 0, num_fields = PQnfields(pg_result); i < num_fields; i++) {
             if (result_type & PGSQL_ASSOC) {
                 zval value;
                 php_pgsql_get_field_value(&value, pg_result, result_type, pg_row, i);
                 field_name = PQfname(pg_result, i);
+                if (0 == strcmp("?column?", field_name)) {
+                    if (unknown_columns > 0) {
+                        field_name = (std::string(field_name) + std::to_string(unknown_columns)).c_str();
+                    }
+                    ++unknown_columns;
+                }
                 add_assoc_zval(&row, field_name, &value);
             }
             if (result_type & PGSQL_NUM) {

--- a/tests/unit/PostgreSQLTest.php
+++ b/tests/unit/PostgreSQLTest.php
@@ -1,15 +1,17 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Swoole\Coroutine\PostgreSQL;
 use function Swoole\Coroutine\run;
-use PHPUnit\Framework\TestCase;
 
 class PostgreSQLTest extends TestCase
 {
-    protected function getConn() {
+    protected function getConn()
+    {
         $pg = new Swoole\Coroutine\PostgreSQL();
         $conn = $pg->connect(TEST_DB_URI);
-        $this->assertNotFalse($conn, (string)$pg->error);
+        $this->assertNotFalse($conn, (string) $pg->error);
+
         return $pg;
     }
 
@@ -18,7 +20,7 @@ class PostgreSQLTest extends TestCase
         run(function () {
             $pg = $this->getConn();
             $result = $pg->escape("' or 1=1 & 2");
-            $this->assertNotFalse($result, (string)$pg->error);
+            $this->assertNotFalse($result, (string) $pg->error);
             $this->assertEquals("'' or 1=1 & 2", $result);
         });
     }
@@ -29,7 +31,7 @@ class PostgreSQLTest extends TestCase
             $pg = $this->getConn();
             $result = $pg->query("INSERT INTO weather(city, temp_lo, temp_hi, prcp, date) 
                         VALUES ('Shanghai', 88, 10, 0.75,'1993-11-27')  RETURNING id");
-            $this->assertNotFalse($result, (string)$pg->error);
+            $this->assertNotFalse($result, (string) $pg->error);
             $this->assertEquals(1, $pg->numRows($result));
             $this->assertGreaterThan(1, $pg->fetchAssoc($result)['id']);
         });
@@ -40,11 +42,25 @@ class PostgreSQLTest extends TestCase
         run(function () {
             $pg = $this->getConn();
             $result = $pg->query('SELECT * FROM weather;');
-            $this->assertNotFalse($result, (string)$pg->error);
+            $this->assertNotFalse($result, (string) $pg->error);
 
             $arr = $pg->fetchAll($result);
             $this->assertIsArray($arr);
             $this->assertEquals($arr[0]['city'], 'San Francisco');
+        });
+    }
+
+    public function testNoFieldName()
+    {
+        run(function () {
+            $pg = $this->getConn();
+            $result = $pg->query('SELECT 11, 22');
+            $this->assertNotFalse($result, (string) $pg->error);
+
+            $arr = $pg->fetchAll($result);
+            $this->assertIsArray($arr);
+            $this->assertEquals($arr[0]['?column?'], 11);
+            $this->assertEquals($arr[0]['?column?1'], 22);
         });
     }
 }


### PR DESCRIPTION
```php
Co\run(function () {
    $db = new Swoole\Coroutine\PostgreSQL();
    $db->connect('host=127.0.0.1 port=5432 dbname=db_imi_test user=root password=root');
    $r = $db->query('select 11, 22');
    var_dump($db->fetchAll($r));
});
```

Before fix result:

```php
array(1) {
  [0]=>
  array(1) {
    ["?column?"]=>
    int(22)
  }
}
```

After fix result:

```php
array(1) {
  [0]=>
  array(2) {
    ["?column?"]=>
    int(11)
    ["?column?1"]=>
    int(22)
  }
}
```
