### PR TITLE
Remove the snake_name parameter of  SW_INIT_CLASS_ENTRY macro.

### DIFF
--- a/swoole_postgresql.cc
+++ b/swoole_postgresql.cc
@@ -277,7 +277,6 @@ static const zend_function_entry swoole_postgresql_coro_methods[] =
 void swoole_postgresql_init(int module_number) {
     SW_INIT_CLASS_ENTRY(swoole_postgresql_coro,
                         "Swoole\\Coroutine\\PostgreSQL",
-                        NULL,
                         "Co\\PostgreSQL",
                         swoole_postgresql_coro_methods);
 #ifdef SW_SET_CLASS_NOT_SERIALIZABLE


### PR DESCRIPTION
使用 Swoole V4.8.6  版本安装 ext-postgresql 报错：

```
/mnt/e/code/git/ext-postgresql/swoole_postgresql.cc:282:55: error: macro "SW_INIT_CLASS_ENTRY" passed 5 arguments, but takes just 4
```

查了一下是因为在 https://github.com/swoole/swoole-src/commit/32d7c65d9a6add46d97ecd5504317f2121185868#diff-ea09b237f582dcc5832afa83849058ab03b214621160256bd8866bff6c1a6d16L613 中删除了 snake_name 参数。

